### PR TITLE
Update TypeScript version and set root directory in tsconfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "semantic-release-cli": "^5.4.4",
     "storybook": "^8.6.18",
     "typed.js": "^2.0.12",
-    "typescript": "^4.7.4",
+    "typescript": "^6.0.3",
     "vitest": "^3.2.6"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,10 +34,10 @@ importers:
         version: 1.0.6(webpack@5.108.4(@swc/core@1.15.46)(esbuild@0.18.20)(postcss@8.5.20))
       '@storybook/react':
         specifier: ^8.6.18
-        version: 8.6.18(@storybook/test@8.6.18(storybook@8.6.18(prettier@2.8.8)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.18(prettier@2.8.8))(typescript@4.9.5)
+        version: 8.6.18(@storybook/test@8.6.18(storybook@8.6.18(prettier@2.8.8)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.18(prettier@2.8.8))(typescript@6.0.3)
       '@storybook/react-webpack5':
         specifier: ^8.6.18
-        version: 8.6.18(@storybook/test@8.6.18(storybook@8.6.18(prettier@2.8.8)))(@swc/core@1.15.46)(esbuild@0.18.20)(postcss@8.5.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.18(prettier@2.8.8))(typescript@4.9.5)
+        version: 8.6.18(@storybook/test@8.6.18(storybook@8.6.18(prettier@2.8.8)))(@swc/core@1.15.46)(esbuild@0.18.20)(postcss@8.5.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.18(prettier@2.8.8))(typescript@6.0.3)
       '@testing-library/dom':
         specifier: ^10.4.0
         version: 10.4.1
@@ -61,10 +61,10 @@ importers:
         version: 3.2.7(vitest@3.2.7(@types/node@26.1.1)(jiti@2.6.1)(jsdom@26.1.0)(terser@5.49.0))
       commitizen:
         specifier: ^4.2.4
-        version: 4.3.2(@types/node@26.1.1)(typescript@4.9.5)
+        version: 4.3.2(@types/node@26.1.1)(typescript@6.0.3)
       cz-conventional-changelog:
         specifier: ^3.3.0
-        version: 3.3.0(@types/node@26.1.1)(typescript@4.9.5)
+        version: 3.3.0(@types/node@26.1.1)(typescript@6.0.3)
       husky:
         specifier: ^3.1.0
         version: 3.1.0
@@ -90,8 +90,8 @@ importers:
         specifier: ^2.0.12
         version: 2.1.0
       typescript:
-        specifier: ^4.7.4
-        version: 4.9.5
+        specifier: ^6.0.3
+        version: 6.0.3
       vitest:
         specifier: ^3.2.6
         version: 3.2.7(@types/node@26.1.1)(jiti@2.6.1)(jsdom@26.1.0)(terser@5.49.0)
@@ -4717,9 +4717,9 @@ packages:
   typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
 
-  typescript@4.9.5:
-    resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
-    engines: {node: '>=4.2.0'}
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
     hasBin: true
 
   uglify-js@3.19.3:
@@ -5197,14 +5197,14 @@ snapshots:
   '@commitlint/execute-rule@21.0.1':
     optional: true
 
-  '@commitlint/load@21.2.0(@types/node@26.1.1)(typescript@4.9.5)':
+  '@commitlint/load@21.2.0(@types/node@26.1.1)(typescript@6.0.3)':
     dependencies:
       '@commitlint/config-validator': 21.2.0
       '@commitlint/execute-rule': 21.0.1
       '@commitlint/resolve-extends': 21.2.0
       '@commitlint/types': 21.2.0
-      cosmiconfig: 9.0.2(typescript@4.9.5)
-      cosmiconfig-typescript-loader: 6.3.0(@types/node@26.1.1)(cosmiconfig@9.0.2(typescript@4.9.5))(typescript@4.9.5)
+      cosmiconfig: 9.0.2(typescript@6.0.3)
+      cosmiconfig-typescript-loader: 6.3.0(@types/node@26.1.1)(cosmiconfig@9.0.2(typescript@6.0.3))(typescript@6.0.3)
       es-toolkit: 1.49.0
       is-plain-obj: 4.1.0
       picocolors: 1.1.1
@@ -5816,7 +5816,7 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@storybook/builder-webpack5@8.6.18(@swc/core@1.15.46)(esbuild@0.18.20)(postcss@8.5.20)(storybook@8.6.18(prettier@2.8.8))(typescript@4.9.5)':
+  '@storybook/builder-webpack5@8.6.18(@swc/core@1.15.46)(esbuild@0.18.20)(postcss@8.5.20)(storybook@8.6.18(prettier@2.8.8))(typescript@6.0.3)':
     dependencies:
       '@storybook/core-webpack': 8.6.18(storybook@8.6.18(prettier@2.8.8))
       '@types/semver': 7.7.1
@@ -5826,7 +5826,7 @@ snapshots:
       constants-browserify: 1.0.0
       css-loader: 6.11.0(webpack@5.108.4(@swc/core@1.15.46)(esbuild@0.18.20)(postcss@8.5.20))
       es-module-lexer: 1.7.0
-      fork-ts-checker-webpack-plugin: 8.0.0(typescript@4.9.5)(webpack@5.108.4(@swc/core@1.15.46)(esbuild@0.18.20)(postcss@8.5.20))
+      fork-ts-checker-webpack-plugin: 8.0.0(typescript@6.0.3)(webpack@5.108.4(@swc/core@1.15.46)(esbuild@0.18.20)(postcss@8.5.20))
       html-webpack-plugin: 5.6.7(webpack@5.108.4(@swc/core@1.15.46)(esbuild@0.18.20)(postcss@8.5.20))
       magic-string: 0.30.21
       path-browserify: 1.0.1
@@ -5844,7 +5844,7 @@ snapshots:
       webpack-hot-middleware: 2.26.1
       webpack-virtual-modules: 0.6.2
     optionalDependencies:
-      typescript: 4.9.5
+      typescript: 6.0.3
     transitivePeerDependencies:
       - '@minify-html/node'
       - '@rspack/core'
@@ -5913,11 +5913,11 @@ snapshots:
     dependencies:
       storybook: 8.6.18(prettier@2.8.8)
 
-  '@storybook/preset-react-webpack@8.6.18(@storybook/test@8.6.18(storybook@8.6.18(prettier@2.8.8)))(@swc/core@1.15.46)(esbuild@0.18.20)(postcss@8.5.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.18(prettier@2.8.8))(typescript@4.9.5)':
+  '@storybook/preset-react-webpack@8.6.18(@storybook/test@8.6.18(storybook@8.6.18(prettier@2.8.8)))(@swc/core@1.15.46)(esbuild@0.18.20)(postcss@8.5.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.18(prettier@2.8.8))(typescript@6.0.3)':
     dependencies:
       '@storybook/core-webpack': 8.6.18(storybook@8.6.18(prettier@2.8.8))
-      '@storybook/react': 8.6.18(@storybook/test@8.6.18(storybook@8.6.18(prettier@2.8.8)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.18(prettier@2.8.8))(typescript@4.9.5)
-      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@4.9.5)(webpack@5.108.4(@swc/core@1.15.46)(esbuild@0.18.20)(postcss@8.5.20))
+      '@storybook/react': 8.6.18(@storybook/test@8.6.18(storybook@8.6.18(prettier@2.8.8)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.18(prettier@2.8.8))(typescript@6.0.3)
+      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@6.0.3)(webpack@5.108.4(@swc/core@1.15.46)(esbuild@0.18.20)(postcss@8.5.20))
       '@types/semver': 7.7.1
       find-up: 5.0.0
       magic-string: 0.30.21
@@ -5930,7 +5930,7 @@ snapshots:
       tsconfig-paths: 4.2.0
       webpack: 5.108.4(@swc/core@1.15.46)(esbuild@0.18.20)(postcss@8.5.20)
     optionalDependencies:
-      typescript: 4.9.5
+      typescript: 6.0.3
     transitivePeerDependencies:
       - '@minify-html/node'
       - '@storybook/test'
@@ -5952,16 +5952,16 @@ snapshots:
     dependencies:
       storybook: 8.6.18(prettier@2.8.8)
 
-  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@4.9.5)(webpack@5.108.4(@swc/core@1.15.46)(esbuild@0.18.20)(postcss@8.5.20))':
+  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@6.0.3)(webpack@5.108.4(@swc/core@1.15.46)(esbuild@0.18.20)(postcss@8.5.20))':
     dependencies:
       debug: 4.4.3
       endent: 2.1.0
       find-cache-dir: 3.3.2
       flat-cache: 3.2.0
       micromatch: 4.0.8
-      react-docgen-typescript: 2.4.0(typescript@4.9.5)
+      react-docgen-typescript: 2.4.0(typescript@6.0.3)
       tslib: 2.8.1
-      typescript: 4.9.5
+      typescript: 6.0.3
       webpack: 5.108.4(@swc/core@1.15.46)(esbuild@0.18.20)(postcss@8.5.20)
     transitivePeerDependencies:
       - supports-color
@@ -5972,16 +5972,16 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       storybook: 8.6.18(prettier@2.8.8)
 
-  '@storybook/react-webpack5@8.6.18(@storybook/test@8.6.18(storybook@8.6.18(prettier@2.8.8)))(@swc/core@1.15.46)(esbuild@0.18.20)(postcss@8.5.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.18(prettier@2.8.8))(typescript@4.9.5)':
+  '@storybook/react-webpack5@8.6.18(@storybook/test@8.6.18(storybook@8.6.18(prettier@2.8.8)))(@swc/core@1.15.46)(esbuild@0.18.20)(postcss@8.5.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.18(prettier@2.8.8))(typescript@6.0.3)':
     dependencies:
-      '@storybook/builder-webpack5': 8.6.18(@swc/core@1.15.46)(esbuild@0.18.20)(postcss@8.5.20)(storybook@8.6.18(prettier@2.8.8))(typescript@4.9.5)
-      '@storybook/preset-react-webpack': 8.6.18(@storybook/test@8.6.18(storybook@8.6.18(prettier@2.8.8)))(@swc/core@1.15.46)(esbuild@0.18.20)(postcss@8.5.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.18(prettier@2.8.8))(typescript@4.9.5)
-      '@storybook/react': 8.6.18(@storybook/test@8.6.18(storybook@8.6.18(prettier@2.8.8)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.18(prettier@2.8.8))(typescript@4.9.5)
+      '@storybook/builder-webpack5': 8.6.18(@swc/core@1.15.46)(esbuild@0.18.20)(postcss@8.5.20)(storybook@8.6.18(prettier@2.8.8))(typescript@6.0.3)
+      '@storybook/preset-react-webpack': 8.6.18(@storybook/test@8.6.18(storybook@8.6.18(prettier@2.8.8)))(@swc/core@1.15.46)(esbuild@0.18.20)(postcss@8.5.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.18(prettier@2.8.8))(typescript@6.0.3)
+      '@storybook/react': 8.6.18(@storybook/test@8.6.18(storybook@8.6.18(prettier@2.8.8)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.18(prettier@2.8.8))(typescript@6.0.3)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       storybook: 8.6.18(prettier@2.8.8)
     optionalDependencies:
-      typescript: 4.9.5
+      typescript: 6.0.3
     transitivePeerDependencies:
       - '@minify-html/node'
       - '@rspack/core'
@@ -6000,7 +6000,7 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@storybook/react@8.6.18(@storybook/test@8.6.18(storybook@8.6.18(prettier@2.8.8)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.18(prettier@2.8.8))(typescript@4.9.5)':
+  '@storybook/react@8.6.18(@storybook/test@8.6.18(storybook@8.6.18(prettier@2.8.8)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.18(prettier@2.8.8))(typescript@6.0.3)':
     dependencies:
       '@storybook/components': 8.6.18(storybook@8.6.18(prettier@2.8.8))
       '@storybook/global': 5.0.0
@@ -6013,7 +6013,7 @@ snapshots:
       storybook: 8.6.18(prettier@2.8.8)
     optionalDependencies:
       '@storybook/test': 8.6.18(storybook@8.6.18(prettier@2.8.8))
-      typescript: 4.9.5
+      typescript: 6.0.3
 
   '@storybook/test@8.6.18(storybook@8.6.18(prettier@2.8.8))':
     dependencies:
@@ -6864,10 +6864,10 @@ snapshots:
 
   commander@8.3.0: {}
 
-  commitizen@4.3.2(@types/node@26.1.1)(typescript@4.9.5):
+  commitizen@4.3.2(@types/node@26.1.1)(typescript@6.0.3):
     dependencies:
       cachedir: 2.4.0
-      cz-conventional-changelog: 3.3.0(@types/node@26.1.1)(typescript@4.9.5)
+      cz-conventional-changelog: 3.3.0(@types/node@26.1.1)(typescript@6.0.3)
       dedent: 0.7.0
       detect-indent: 6.1.0
       find-node-modules: 2.1.3
@@ -6972,12 +6972,12 @@ snapshots:
 
   core-util-is@1.0.3: {}
 
-  cosmiconfig-typescript-loader@6.3.0(@types/node@26.1.1)(cosmiconfig@9.0.2(typescript@4.9.5))(typescript@4.9.5):
+  cosmiconfig-typescript-loader@6.3.0(@types/node@26.1.1)(cosmiconfig@9.0.2(typescript@6.0.3))(typescript@6.0.3):
     dependencies:
       '@types/node': 26.1.1
-      cosmiconfig: 9.0.2(typescript@4.9.5)
+      cosmiconfig: 9.0.2(typescript@6.0.3)
       jiti: 2.6.1
-      typescript: 4.9.5
+      typescript: 6.0.3
     optional: true
 
   cosmiconfig@5.2.1:
@@ -6995,14 +6995,14 @@ snapshots:
       path-type: 4.0.0
       yaml: 1.10.3
 
-  cosmiconfig@9.0.2(typescript@4.9.5):
+  cosmiconfig@9.0.2(typescript@6.0.3):
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
       js-yaml: 4.3.0
       parse-json: 5.2.0
     optionalDependencies:
-      typescript: 4.9.5
+      typescript: 6.0.3
     optional: true
 
   cross-spawn@5.1.0:
@@ -7065,16 +7065,16 @@ snapshots:
 
   cyclist@1.0.2: {}
 
-  cz-conventional-changelog@3.3.0(@types/node@26.1.1)(typescript@4.9.5):
+  cz-conventional-changelog@3.3.0(@types/node@26.1.1)(typescript@6.0.3):
     dependencies:
       chalk: 2.4.2
-      commitizen: 4.3.2(@types/node@26.1.1)(typescript@4.9.5)
+      commitizen: 4.3.2(@types/node@26.1.1)(typescript@6.0.3)
       conventional-commit-types: 3.0.0
       lodash.map: 4.6.0
       longest: 2.0.1
       word-wrap: 1.2.5
     optionalDependencies:
-      '@commitlint/load': 21.2.0(@types/node@26.1.1)(typescript@4.9.5)
+      '@commitlint/load': 21.2.0(@types/node@26.1.1)(typescript@6.0.3)
     transitivePeerDependencies:
       - '@types/node'
       - typescript
@@ -7534,7 +7534,7 @@ snapshots:
 
   forever-agent@0.6.1: {}
 
-  fork-ts-checker-webpack-plugin@8.0.0(typescript@4.9.5)(webpack@5.108.4(@swc/core@1.15.46)(esbuild@0.18.20)(postcss@8.5.20)):
+  fork-ts-checker-webpack-plugin@8.0.0(typescript@6.0.3)(webpack@5.108.4(@swc/core@1.15.46)(esbuild@0.18.20)(postcss@8.5.20)):
     dependencies:
       '@babel/code-frame': 7.29.7
       chalk: 4.1.2
@@ -7548,7 +7548,7 @@ snapshots:
       schema-utils: 3.3.0
       semver: 7.8.5
       tapable: 2.3.3
-      typescript: 4.9.5
+      typescript: 6.0.3
       webpack: 5.108.4(@swc/core@1.15.46)(esbuild@0.18.20)(postcss@8.5.20)
 
   form-data@2.3.3:
@@ -8939,9 +8939,9 @@ snapshots:
       minimist: 1.2.8
       strip-json-comments: 2.0.1
 
-  react-docgen-typescript@2.4.0(typescript@4.9.5):
+  react-docgen-typescript@2.4.0(typescript@6.0.3):
     dependencies:
-      typescript: 4.9.5
+      typescript: 6.0.3
 
   react-docgen@7.1.1:
     dependencies:
@@ -9724,7 +9724,7 @@ snapshots:
 
   typedarray@0.0.6: {}
 
-  typescript@4.9.5: {}
+  typescript@6.0.3: {}
 
   uglify-js@3.19.3:
     optional: true

--- a/src/css.d.ts
+++ b/src/css.d.ts
@@ -1,0 +1,1 @@
+declare module "*.css";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,10 +4,11 @@
     "jsx": "react",
     "declaration": true,
     "esModuleInterop": true,
+    "rootDir": "./src",
     "outDir": "dist",
     "target": "es6",
     "module": "es6",
-    "moduleResolution": "node"
+    "moduleResolution": "bundler"
   },
   "include": ["src"],
   "exclude": ["src/*.stories.tsx", "src/**/*.test.tsx", "src/test/**"]


### PR DESCRIPTION
- Upgraded TypeScript from version 4.7.4 to 6.0.3 in package.json to leverage new features and improvements.
- Added "rootDir": "./src" in tsconfig.json to specify the root directory for TypeScript source files, enhancing project structure clarity.